### PR TITLE
预约商品改为当前就可以预约

### DIFF
--- a/jd_spider_requests.py
+++ b/jd_spider_requests.py
@@ -376,7 +376,7 @@ class JdSeckill(object):
         resp = self.session.get(url=url, params=payload, headers=headers)
         resp_json = parse_json(resp.text)
         reserve_url = resp_json.get('url')
-        self.timers.start()
+        # self.timers.start()
         while True:
             try:
                 self.session.get(url='https:' + reserve_url)


### PR DESCRIPTION
之前的预约一直预约不上，看了下代码，逻辑是等到抢购时间才会执行下面的预约逻辑，我就把他改成当前时间直接预约