### PR TITLE
docker-compose支持build镜像

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -3,6 +3,9 @@ services:
   jd-seckill:
     container_name: jd-seckill
     image: jd-seckill:latest
+    build:
+      context: ../dockerfile
+      dockerfile: Dockerfile
     environment:
       # eid, fp参数必须填写，具体请参考 wiki-常见问题
       # 随意填写可能导致订单无法提交等问题


### PR DESCRIPTION
当使用docker-compose up时发现镜像不存在，默认执行docker build先构建镜像，然后再启动容器