### PR TITLE
修正ubuntu解析二维码输出到命令行窗口bash命令

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@
 
 ```bash
 $ sudo apt-get install qrencode zbar-tools # 安装二维码解析和生成的工具，用于读取二维码并在命令行输出。
-$ zbarimg qr_code.png > qrcode.txt && qrencode -r qrcode.txt -o - -t UTF8 # 解析二维码输出到命令行窗口。
+$ zbarimg qr_code.png > qrcode.txt && cat qrcode.txt | qrencode -o - -t UTF8 # 解析二维码输出到命令行窗口。
 ```
 
 #### 5.抢购结果确认 


### PR DESCRIPTION
## qrencode -r 报错
```bash
qrencode: invalid option -- 'r'
Try `qrencode --help' for more information.
```

## qrencode --help
```
qrencode version 3.4.4
Copyright (C) 2006-2012 Kentaro Fukuchi
Usage: qrencode [OPTION]... [STRING]
Encode input data in a QR Code and save as a PNG or EPS image.

  -h, --help   display the help message. -h displays only the help of short
               options.

  -o FILENAME, --output=FILENAME
               write image to FILENAME. If '-' is specified, the result
               will be output to standard output. If -S is given, structured
               symbols are written to FILENAME-01.png, FILENAME-02.png, ...
               (suffix is removed from FILENAME, if specified)
  -s NUMBER, --size=NUMBER
               specify module size in dots (pixels). (default=3)

  -l {LMQH}, --level={LMQH}
               specify error correction level from L (lowest) to H (highest).
               (default=L)

  -v NUMBER, --symversion=NUMBER
               specify the version of the symbol. See SYMBOL VERSIONS for more
               information. (default=auto)

  -m NUMBER, --margin=NUMBER
               specify the width of the margins. (default=4 (2 for Micro QR)))

  -d NUMBER, --dpi=NUMBER
               specify the DPI of the generated PNG. (default=72)

  -t {PNG,EPS,SVG,ANSI,ANSI256,ASCII,ASCIIi,UTF8,ANSIUTF8}, --type={PNG,EPS,
               SVG,ANSI,ANSI256,ASCII,ASCIIi,UTF8,ANSIUTF8}
               specify the type of the generated image. (default=PNG)

  -S, --structured
               make structured symbols. Version must be specified.

  -k, --kanji  assume that the input text contains kanji (shift-jis).

  -c, --casesensitive
               encode lower-case alphabet characters in 8-bit mode. (default)

  -i, --ignorecase
               ignore case distinctions and use only upper-case characters.

  -8, --8bit   encode entire data in 8-bit mode. -k, -c and -i will be ignored.

      --rle    enable run-length encoding for SVG.

  -M, --micro  encode in a Micro QR Code. (experimental)

      --foreground=RRGGBB[AA]
      --background=RRGGBB[AA]
               specify foreground/background color in hexadecimal notation.
               6-digit (RGB) or 8-digit (RGBA) form are supported.
               Color output support available only in PNG and SVG.
  -V, --version
               display the version number and copyrights of the qrencode.

      --verbose
               display verbose information to stderr.

  [STRING]     input data. If it is not specified, data will be taken from
               standard input.

*SYMBOL VERSIONS
               The symbol versions of QR Code range from Version 1 to Version
               40. Each version has a different module configuration or number
               of modules, ranging from Version 1 (21 x 21 modules) up to
               Version 40 (177 x 177 modules). Each higher version number
               comprises 4 additional modules per side by default. See
               http://www.qrcode.com/en/about/version.html for a detailed
               version list.
```